### PR TITLE
ci: add the windows lane with junction harness links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-# CI gate: typecheck + full tests on a clean Linux runner.
+# CI gate: typecheck + full tests on clean Linux and Windows runners.
 #
 # The environment contract lives in docs/development.md § "Sandbox and CI
 # environments" — the same six-step contract as the hoplite sandbox setup in
@@ -6,8 +6,10 @@
 # DSH_HARNESS_TAG env below, docs/development.md, and .hoplite/settings.json
 # together; keep the three in sync by hand, there is no generator on purpose.
 #
-# Scope guard: one workflow, one Linux job. No coverage matrix, no release
-# automation, no test:browser (that stays a local acceptance step).
+# Scope guard: one workflow, two jobs (linux + windows). No coverage matrix,
+# no release automation, no test:browser (that stays a local acceptance step).
+# The windows lane is the regression fence for filesystem-identifier bugs
+# (issues #7/#8): string-level sanitizing must hold on a real Windows FS.
 name: ci
 
 on:
@@ -58,6 +60,43 @@ jobs:
       - name: Regenerate TypeScript path facades
         # sync-paths is not part of any npm script; skipping it leaves the
         # committed facades pointing at their generation-time paths.
+        run: node scripts/sync-paths.mjs
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+  windows:
+    runs-on: windows-latest
+    steps:
+      - name: Check out this repository
+        uses: actions/checkout@v4
+
+      - name: Check out the pinned Harness release as the default sibling
+        # Same sibling contract; git bash resolves ../ the same way.
+        run: |
+          git clone --depth 1 --branch "$env:DSH_HARNESS_TAG" \
+            https://github.com/deepseek-ai/deepseek-harness.git ../deepseek-harness
+
+      - name: Install and build the Harness workspace
+        run: |
+          cd ../deepseek-harness
+          corepack pnpm install
+          corepack pnpm build:lib
+
+      - name: Install this repository
+        run: corepack pnpm install
+
+      - name: Link harness packages and build the bundle
+        # link-harness-packages uses directory junctions on win32, so no
+        # symlink privilege is needed.
+        run: |
+          node scripts/link-harness-packages.mjs
+          npm run build
+
+      - name: Regenerate TypeScript path facades
         run: node scripts/sync-paths.mjs
 
       - name: Typecheck

--- a/scripts/link-harness-packages.mjs
+++ b/scripts/link-harness-packages.mjs
@@ -29,7 +29,15 @@ const linkPackage = (name, packageDir) => {
   if (existsSync(target)) return
   // node_modules/<scope>/<name> -> ../../../deepseek-harness/<packageDir>
   const relativeTarget = relative(scopeRoot, packageDir)
-  symlinkSync(relativeTarget, target, 'dir')
+  if (process.platform === 'win32') {
+    // Windows needs symlink privilege (admin or developer mode) for real
+    // symlinks; directory junctions need none and behave the same for this
+    // purpose. CI windows runners are admin, but junction keeps local
+    // non-admin setups working too.
+    symlinkSync(relativeTarget, target, 'junction')
+  } else {
+    symlinkSync(relativeTarget, target, 'dir')
+  }
   linked += 1
 }
 for (const area of readdirSync(packagesRoot, { withFileTypes: true })) {
@@ -62,7 +70,11 @@ if (existsSync(vendorRoot)) {
 const selfRef = join(repoRoot, 'node_modules', '@wowyuarm')
 mkdirSync(selfRef, { recursive: true })
 if (!existsSync(join(selfRef, 'dsh-agent-team'))) {
-  symlinkSync(relative(selfRef, repoRoot), join(selfRef, 'dsh-agent-team'), 'dir')
+  if (process.platform === 'win32') {
+    symlinkSync(relative(selfRef, repoRoot), join(selfRef, 'dsh-agent-team'), 'junction')
+  } else {
+    symlinkSync(relative(selfRef, repoRoot), join(selfRef, 'dsh-agent-team'), 'dir')
+  }
   linked += 1
 }
 console.log(`linked ${linked} Harness packages into node_modules`)


### PR DESCRIPTION
Phase 2 of the CI plan (thread task:cce49139): the windows regression fence.

## What

- **windows job** in ci.yml: same eight-step contract as linux (sibling harness clone at the certified tag, pnpm install + build:lib, repo install, link + build, sync-paths, typecheck, test) on windows-latest.
- **link-harness-packages.mjs**: directory links switch to junctions on win32 — no symlink privilege needed (GitHub runners are admin anyway; junctions also keep local non-admin Windows setups working). Linux path unchanged ('dir' symlinks).
- Windows-specific detail: the env var expansion in git bash uses $env:DSH_HARNESS_TAG.

## Why this lane

Issues #7/#8 were both string-level sanitizing bugs invisible on Linux — the whole team develops on Linux. This lane runs writeAttachment and the member memory-dir logic against a real Windows filesystem on every PR, closing the "works on my machine" gap for the filesystem-identifier bug family. The #8 fix (merged in 80de408) is its first regression target.

## Verification

- YAML parses: jobs linux+windows, 8 steps each.
- link script Linux regression: linked 258→0 skips (idempotent), typecheck exit 0, attachments spec 13/13.
- The acceptance is this PR: both lanes must run green here once. First windows run is expected to surface environment issues (junction behavior, path length) — red stays blocked until fixed, same rule as Phase 1.

## Non-goals

Coverage matrix, release automation, test:browser, macOS (not justified by any observed bug family), pnpm store caching (performance follow-up only if cold install proves slow).